### PR TITLE
Fix fetching results in AFM example via PulserQLMConnection

### DIFF
--- a/tutorials/AFM_PulserQLMConnection.py
+++ b/tutorials/AFM_PulserQLMConnection.py
@@ -56,7 +56,7 @@ seq.add(interpolated_pulse, "ising")
 qpu = QPUBackend(seq, connection=conn)
 
 remote_results = qpu.run([JobParams(runs=1000, variables=[])], wait=True)
-count = remote_results.get_available_results().values()[0]
+count = remote_results[0].bitstring_counts
 
 # Print the most interesting samples
 print("Obtained samples:", count)


### PR DESCRIPTION
Current way doesn't work because values() is not indexable. Since we are waiting for results to be ready before fetching them, we can use results[0] directly, without risking an error.